### PR TITLE
docs: add reminder to define environment variables in .env files

### DIFF
--- a/docs/13_variables-entorno.md
+++ b/docs/13_variables-entorno.md
@@ -1,4 +1,12 @@
 
+**Recordatorio importante:**
+
+Para que las aplicaciones funcionen correctamente, es imprescindible definir las variables de entorno necesarias en los archivos `.env` correspondientes de cada app:
+- `apps/frontend/.env` para el frontend (Next.js)
+- `apps/api/.env` para el backend (Express)
+
+Asegúrate de crear y mantener estos archivos con las variables requeridas antes de ejecutar cada aplicación.
+
 En este monorepo, donde se tiene una aplicación frontend (Next.js) y una API backend (Express), cada una maneja sus propias variables de entorno de forma independiente. Aquí te explico cómo funciona generalmente:
 
 ### Variables de Entorno del Frontend (Next.js en `apps/frontend`)


### PR DESCRIPTION
Add a reminder in the documentation to ensure that the necessary environment variables are defined in the respective `.env` files for the frontend and backend applications. This is crucial for the applications to function correctly.