### PR TITLE
style(ImageProcessor): format SVG elements for improved readability a…

### DIFF
--- a/apps/frontend/components/ImageProcessor.tsx
+++ b/apps/frontend/components/ImageProcessor.tsx
@@ -209,9 +209,21 @@ function ProcessingTimer() {
           {/* Cuerpo */}
           <ellipse cx="0" cy="8" rx="12" ry="8" fill="#a3e635" />
           {/* Concha */}
-          <circle cx="-6" cy="4" r="7" fill="#fde68a" stroke="#b45309" strokeWidth="2" />
+          <circle
+            cx="-6"
+            cy="4"
+            r="7"
+            fill="#fde68a"
+            stroke="#b45309"
+            strokeWidth="2"
+          />
           {/* Espiral de la concha */}
-          <path d="M-6 4 q2 2 0 4 q-2 2 0 4" stroke="#b45309" strokeWidth="1.2" fill="none" />
+          <path
+            d="M-6 4 q2 2 0 4 q-2 2 0 4"
+            stroke="#b45309"
+            strokeWidth="1.2"
+            fill="none"
+          />
           {/* Ojos */}
           <ellipse cx="7" cy="0" rx="2" ry="4" fill="#a3e635" />
           <ellipse cx="-7" cy="0" rx="2" ry="4" fill="#a3e635" />


### PR DESCRIPTION
This pull request makes a small formatting change to improve the readability of the SVG element definitions in the `ProcessingTimer` function within the `ImageProcessor.tsx` file. Specifically, it adjusts the indentation and line breaks for the `circle` and `path` elements.

* [`apps/frontend/components/ImageProcessor.tsx`](diffhunk://#diff-38c213c828d1f06f467cc2410111b6b853d16b024a604cc50a7bb932eb68cf0aL212-R226): Reformatted the `circle` and `path` SVG elements by breaking their attributes into multiple lines for better readability.…nd maintainability