### PR TITLE
Refactor Clerk component to use fallbackRedirectUrl

### DIFF
--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/apps/frontend/app/[[...rest]]/page.tsx
+++ b/apps/frontend/app/[[...rest]]/page.tsx
@@ -44,8 +44,7 @@ export default function Home() {
           }}
           routing="path"
           signUpUrl="/sign-up"
-          afterSignInUrl="/dashboard"
-          afterSignUpUrl="/dashboard"
+          fallbackRedirectUrl="/dashboard"
         />
       </main>
 


### PR DESCRIPTION
Update the Clerk component to utilize `fallbackRedirectUrl` instead of the previous `afterSignInUrl` and `afterSignUpUrl` for redirecting users after sign-in and sign-up.